### PR TITLE
CMake: use GNUInstallDirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,11 +37,42 @@ IF(BUILD_STATIC)
   set (CMAKE_CXX_FLAGS "-static -static-libgcc ${CMAKE_CXX_FLAGS}")
 ENDIF()
 
+# Check compression program
+# COMPRESS_PROGRAM controls the choice of program
+# COMPRESS_EXT can be used to override the file extension
+if (NOT COMPRESS_PROGRAM)
+  set (COMPRESS_PROGRAM gzip CACHE STRING "Set program for compressing documentation" FORCE)
+endif ()
+find_program (COMPRESS_BIN NAMES ${COMPRESS_PROGRAM} DOC "${COMPRESS_PROGRAM} compression program")
+if (NOT COMPRESS_BIN)
+  message (STATUS "${COMPRESS_PROGRAM} program not found, text doc will not be compressed")
+else ()
+  # Deduce COMPRESS_EXT for known compression programs if not set
+  if (NOT COMPRESS_EXT)
+    if (${COMPRESS_PROGRAM} STREQUAL "gzip")
+      set (COMPRESS_EXT "gz")
+    elseif (${COMPRESS_PROGRAM} STREQUAL "bzip2")
+      set (COMPRESS_EXT "bz2")
+    else ()
+      set (COMPRESS_EXT "${COMPRESS_PROGRAM}") # Default: program name (works for xz/lzma)
+    endif ()
+  endif ()
+  # Generate command line args (always add -c to output compressed file to stdout)
+  if (${COMPRESS_PROGRAM} STREQUAL "gzip")
+    # -n for no timestamp in files (reproducible builds)
+    set (COMPRESS_ARGS -c -n)
+  else ()
+    set (COMPRESS_ARGS -c)
+  endif ()
+  message (STATUS "Found ${COMPRESS_BIN} compression program, using file extension .${COMPRESS_EXT}")
+endif ()
+
 # Find dependencies (add install directory to search)
 if (CMAKE_INSTALL_PREFIX)
   set (CMAKE_PREFIX_PATH "${CMAKE_INSTALL_PREFIX}" ${CMAKE_PREFIX_PATH})
 endif (CMAKE_INSTALL_PREFIX)
 
+include (GNUInstallDirs)
 find_package (bpp-qt 1.0.1 REQUIRED)
 
 # Find the Qt installation

--- a/bppPhyView/CMakeLists.txt
+++ b/bppPhyView/CMakeLists.txt
@@ -23,4 +23,4 @@ else (BUILD_STATIC)
   target_link_libraries (phyview ${BPP_LIBS_SHARED} ${qt-libs})
 endif (BUILD_STATIC)
 
-install (TARGETS phyview DESTINATION bin)
+install (TARGETS ${bppsuite-targets} DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/bppPhyView/CMakeLists.txt
+++ b/bppPhyView/CMakeLists.txt
@@ -23,4 +23,4 @@ else (BUILD_STATIC)
   target_link_libraries (phyview ${BPP_LIBS_SHARED} ${qt-libs})
 endif (BUILD_STATIC)
 
-install (TARGETS ${bppsuite-targets} DESTINATION ${CMAKE_INSTALL_BINDIR})
+install (TARGETS phyview DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/bppphyview.spec
+++ b/bppphyview.spec
@@ -66,19 +66,19 @@ AutoProv: yes
 %if 0%{?mandriva_version}
 %if %{mandriva_version} >= 2011
 BuildRequires: xz
-%define zipext xz
+%define compress_program xz
 %else
 BuildRequires: lzma
-%define zipext lzma
+%define compress_program lzma
 %endif
 %else
 %if 0%{?distribution:1} && "%{distribution}" == "Mageia"
 BuildRequires: xz
-%define zipext xz
+%define compress_program xz
 %else
 #For all other distributions:
 BuildRequires: gzip
-%define zipext gz
+%define compress_program gzip
 %endif
 %endif
 
@@ -89,18 +89,8 @@ Bio++ Phylogenetic Viewer, using the Qt library.
 %setup -q
 
 %build
-CFLAGS="-I%{_prefix}/include $RPM_OPT_FLAGS"
-CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=%{_prefix}"
-if [ %{_lib} == 'lib64' ] ; then
-  CMAKE_FLAGS="$CMAKE_FLAGS -DLIB_SUFFIX=64"
-fi
-if [ %{zipext} == 'lzma' ] ; then
-  CMAKE_FLAGS="$CMAKE_FLAGS -DDOC_COMPRESS=lzma -DDOC_COMPRESS_EXT=lzma"
-fi
-if [ %{zipext} == 'xz' ] ; then
-  CMAKE_FLAGS="$CMAKE_FLAGS -DDOC_COMPRESS=xz -DDOC_COMPRESS_EXT=xz"
-fi
-
+CFLAGS="$RPM_OPT_FLAGS"
+CMAKE_FLAGS="-DCMAKE_INSTALL_PREFIX=%{_prefix} -DCOMPRESS_PROGRAM=%{compress_program}"
 cmake $CMAKE_FLAGS .
 make
 
@@ -118,7 +108,7 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(-,root,root)
 %doc AUTHORS.txt COPYING.txt INSTALL.txt ChangeLog
 %{_prefix}/bin/phyview
-%{_prefix}/share/man/man1/phyview.1.%{zipext}
+%{_prefix}/share/man/man1/phyview.1*
 
 %changelog
 * Mon Sep 28 2014 Julien Dutheil <julien.dutheil@univ-montp2.fr> 0.4.0-1

--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -5,32 +5,33 @@
 # Created: 22/08/2009
 
 # Build manpages.
-# In practice, they are just compressed from the text files using gzip.
-# Manpages are built and installed as part of "all" if gzip is found.
+# In practice, they are just compressed from the text files using COMPRESS_PROGRAM
+# Manpages are built and installed as part of "all" if a COMPRESS_PROGRAM is found.
 
-find_program (GZIP NAMES gzip DOC "gzip compression program")
-if (NOT GZIP)
-  message (STATUS "gzip program not found: 'man' target disabled (builds manpages)")
-else (NOT GZIP)
-  message (STATUS "Found gzip as '${GZIP}': 'man' target enabled (builds manpages)")
+# Take all manpages files in the directory
+file (GLOB manpage_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.1)
 
+if (NOT COMPRESS_BIN)
+  # Just install manpages from source
+  foreach (manpage_file ${manpage_files})
+    install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/${manpage_file} DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
+  endforeach (manpage_file)
+else ()
   # Create a list of manpage targets
   set (manpage-targets)
 
-  # Take all manpages files in the directory
-  file (GLOB manpage_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.1)
   foreach (manpage_file ${manpage_files})
-    # Compress manpage, install, add to manpage list
+    # Compress manpage, install, add to manpage target list
     set (input ${CMAKE_CURRENT_SOURCE_DIR}/${manpage_file})
-    set (output ${CMAKE_CURRENT_BINARY_DIR}/${manpage_file}.gz)
+    set (output ${CMAKE_CURRENT_BINARY_DIR}/${manpage_file}.${COMPRESS_EXT})
     add_custom_command (
       OUTPUT ${output}
-      COMMAND ${GZIP} -c ${input} > ${output}
+      COMMAND ${COMPRESS_BIN} ${COMPRESS_ARGS} ${input} > ${output}
       DEPENDS ${input}
       COMMENT "Compressing manpage ${manpage_file}"
       VERBATIM
       )
-    install (FILES ${output} DESTINATION share/man/man1)
+    install (FILES ${output} DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
     list (APPEND manpage-targets ${output})
     unset (input)
     unset (output)
@@ -38,4 +39,4 @@ else (NOT GZIP)
 
   # Add target "man", built with "all" (needed because install will fail if not built).
   add_custom_target (man ALL DEPENDS ${manpage-targets})
-endif (NOT GZIP)
+endif ()


### PR DESCRIPTION
Better support distrib-specific paths by using the CMake standard module GNUInstallDirs.
This modules defines distrib specific install paths.
Use bindir for binaries.
Also use mandir for man pages.
Man pages are now compressed if a compression program is available.
Reestablished support for multiple compression programs.
Also updated .spec file to reflect the new paths and compression program system.